### PR TITLE
Fix image flicker issue when showing image

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -9,6 +9,7 @@ import UIKit
 public final class Agrume: UIViewController {
 
     private static let TransitionAnimationDuration: NSTimeInterval = 0.3
+    private static let InitialScalingToExpandFrom: CGFloat = 0.6
     private static let MaxScalingForExpandingOffscreen: CGFloat = 1.25
 
     private static let ReuseIdentifier = "ReuseIdentifier"
@@ -133,26 +134,26 @@ public final class Agrume: UIViewController {
 
         view.userInteractionEnabled = false
         initialOrientation = UIApplication.sharedApplication().statusBarOrientation
-
-        viewController.presentViewController(self, animated: false) {
+    
+        dispatch_async(dispatch_get_main_queue()) {
             self.collectionView.alpha = 0
             self.collectionView.frame = self.view.bounds
-            let scaling = Agrume.MaxScalingForExpandingOffscreen
+            let scaling = InitialScalingToExpandFrom
             self.collectionView.transform = CGAffineTransformMakeScale(scaling, scaling)
-
-            dispatch_async(dispatch_get_main_queue()) {
+        
+            viewController.presentViewController(self, animated: false) {
                 UIView.animateWithDuration(Agrume.TransitionAnimationDuration,
-                        delay: 0,
-                        options: [.BeginFromCurrentState, .CurveEaseInOut],
-                        animations: {
-                            [weak self] in
-                            self?.collectionView.alpha = 1
-                            self?.collectionView.transform = CGAffineTransformIdentity
-                        },
-                        completion: {
-                            [weak self] finished in
-                            self?.view.userInteractionEnabled = finished
-                        }
+                    delay: 0,
+                    options: [.BeginFromCurrentState, .CurveEaseInOut],
+                    animations: {
+                        [weak self] in
+                        self?.collectionView.alpha = 1
+                        self?.collectionView.transform = CGAffineTransformIdentity
+                    },
+                    completion: {
+                        [weak self] finished in
+                        self?.view.userInteractionEnabled = finished
+                    }
                 )
             }
         }

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -138,7 +138,7 @@ public final class Agrume: UIViewController {
         dispatch_async(dispatch_get_main_queue()) {
             self.collectionView.alpha = 0
             self.collectionView.frame = self.view.bounds
-            let scaling = InitialScalingToExpandFrom
+            let scaling = Agrume.InitialScalingToExpandFrom
             self.collectionView.transform = CGAffineTransformMakeScale(scaling, scaling)
         
             viewController.presentViewController(self, animated: false) {


### PR DESCRIPTION
The original approach set alpha and scaling etc after viewController.presentViewController(self, animated: false) call, which will present the 100% scaled VC on screen first then make it become invisible and scale, thus cause a flicker. Moving the alpha part before presentVC fixes that.

Also, the off screen initial scale doesn't seem reasonable so I changed it to a smaller scale which looks more natural. Later on Agrume could provide different showing options.