### PR TITLE
Added dispatch_async in cellForRowAtIndexPath method (when imageForIndex is called)

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -327,9 +327,11 @@ extension Agrume: UICollectionViewDataSource {
 			let index = indexPath.row
 			
 			dataSource.imageForIndex(index) { [weak self] image in
-				if collectionView.indexPathsForVisibleItems().contains(indexPath) {
-					cell.image = image
-					self?.spinner.alpha = 0
+				dispatch_async(dispatch_get_main_queue()) {
+					if collectionView.indexPathsForVisibleItems().contains(indexPath) {
+						cell.image = image
+						self?.spinner.alpha = 0
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the bug when spinner would not hide after the image is provided by the dataSource (please see discussion here https://github.com/JanGorman/Agrume/pull/16).

Thanks!