### PR TITLE
Fixed incorrect UICollectionView offset after orientation change

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -277,8 +277,15 @@ extension Agrume {
     backgroundImageView.transform = CGAffineTransformConcat(transform, CGAffineTransformMakeScale(1, 1))
 
     spinner.center = view.center
+    
+    let width = collectionView.bounds.size.width
+    let page = Int((collectionView.contentOffset.x + (0.5 * width)) / width)
+    
     collectionView.frame = view.bounds
-
+    
+    let updatedOffset = CGFloat(page) * collectionView.frame.size.width
+    collectionView.contentOffset = CGPoint(x: updatedOffset, y: collectionView.contentOffset.y)
+    
     let layout = collectionView.collectionViewLayout as! UICollectionViewFlowLayout
     layout.itemSize = view.bounds.size
     layout.invalidateLayout()


### PR DESCRIPTION
Noticed a bug when Argume controller presented with multiple images - after changing orientation it shows incorrect image.

I think it's connected to issue #11.

Fixed by adjusting UICollectionView content offset after changing it's frame.