### PR TITLE
Allow configuring the background view controller to snapshot

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -184,8 +184,8 @@ public final class Agrume: UIViewController {
 
   private var initialOrientation: UIDeviceOrientation!
 
-  public func showFrom(viewController: UIViewController) {
-    backgroundSnapshot = UIApplication.sharedApplication().delegate?.window??.rootViewController?.view.snapshot()
+  public func showFrom(viewController: UIViewController, backgroundSnapshotVC: UIViewController? = .None) {
+    backgroundSnapshot = (backgroundSnapshotVC ?? UIApplication.sharedApplication().delegate?.window??.rootViewController)?.view.snapshot()
     view.frame = frameForCurrentDeviceOrientation()
     view.userInteractionEnabled = false
     initialOrientation = deviceOrientationFromStatusBarOrientation()

--- a/Example/Agrume Example.xcodeproj/project.pbxproj
+++ b/Example/Agrume Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E77809E31D17821400CC60F1 /* SingleImageModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77809E21D17821400CC60F1 /* SingleImageModalViewController.swift */; };
 		F20F5BD41B134CAF00F9F499 /* Agrume.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2A520401B130CC000924912 /* Agrume.framework */; };
 		F2A5201B1B130C7E00924912 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A5201A1B130C7E00924912 /* AppDelegate.swift */; };
 		F2A5201D1B130C7E00924912 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A5201C1B130C7E00924912 /* ViewController.swift */; };
@@ -53,6 +54,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		E77809E21D17821400CC60F1 /* SingleImageModalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleImageModalViewController.swift; sourceTree = "<group>"; };
 		F2A520151B130C7E00924912 /* Agrume Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Agrume Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2A520191B130C7E00924912 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F2A5201A1B130C7E00924912 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 				F2A520231B130C7E00924912 /* LaunchScreen.xib */,
 				F2A520181B130C7E00924912 /* Supporting Files */,
 				F2D9598D1B1A133800073772 /* SingleImageViewController.swift */,
+				E77809E21D17821400CC60F1 /* SingleImageModalViewController.swift */,
 				F2D959901B1A140200073772 /* SingleURLViewController.swift */,
 				F2D959921B1A153F00073772 /* MultipleImagesCollectionViewController.swift */,
 				F2D959941B1A15ED00073772 /* DemoCell.swift */,
@@ -289,6 +292,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E77809E31D17821400CC60F1 /* SingleImageModalViewController.swift in Sources */,
 				F2D959911B1A140200073772 /* SingleURLViewController.swift in Sources */,
 				F2A5201D1B130C7E00924912 /* ViewController.swift in Sources */,
 				F2D959951B1A15ED00073772 /* DemoCell.swift in Sources */,

--- a/Example/Agrume Example/Base.lproj/Main.storyboard
+++ b/Example/Agrume Example/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="hvw-Fc-Hya">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="hvw-Fc-Hya">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -36,8 +36,28 @@
                                             <segue destination="hJu-qU-eYQ" kind="show" id="tju-mP-SxC"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="X1o-ud-2Lf" style="IBUITableViewCellStyleDefault" id="Y3u-BR-FIv">
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="X5Q-TL-Ye4" style="IBUITableViewCellStyleDefault" id="P2k-4H-XYA">
                                         <rect key="frame" x="0.0" y="108" width="600" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="P2k-4H-XYA" id="CI0-n8-Oon">
+                                            <rect key="frame" x="0.0" y="0.0" width="567" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Single Image (Presented Modally)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="X5Q-TL-Ye4">
+                                                    <rect key="frame" x="15" y="0.0" width="550" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="Ndg-rS-gmV" kind="presentation" id="oIO-uH-bn1"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="X1o-ud-2Lf" style="IBUITableViewCellStyleDefault" id="Y3u-BR-FIv">
+                                        <rect key="frame" x="0.0" y="152" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Y3u-BR-FIv" id="wnK-Jn-DTV">
                                             <rect key="frame" x="0.0" y="0.0" width="567" height="43.5"/>
@@ -57,7 +77,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="KA2-Jt-so7" style="IBUITableViewCellStyleDefault" id="S2t-PK-6Yf">
-                                        <rect key="frame" x="0.0" y="152" width="600" height="44"/>
+                                        <rect key="frame" x="0.0" y="196" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="S2t-PK-6Yf" id="GoN-iW-IGx">
                                             <rect key="frame" x="0.0" y="0.0" width="567" height="43.5"/>
@@ -77,7 +97,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="7Ry-kq-3Ny" style="IBUITableViewCellStyleDefault" id="0zw-Kd-4qa">
-                                        <rect key="frame" x="0.0" y="196" width="600" height="44"/>
+                                        <rect key="frame" x="0.0" y="240" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0zw-Kd-4qa" id="XcZ-9j-6kr">
                                             <rect key="frame" x="0.0" y="0.0" width="567" height="43.5"/>
@@ -225,6 +245,47 @@
             </objects>
             <point key="canvasLocation" x="477" y="107"/>
         </scene>
+        <!--Single Image Modal View Controller-->
+        <scene sceneID="hAb-Jd-kU7">
+            <objects>
+                <viewController id="oam-Ti-ubu" customClass="SingleImageModalViewController" customModule="Agrume_Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="t9j-iU-9f6"/>
+                        <viewControllerLayoutGuide type="bottom" id="E5V-KD-KLe"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="T8y-kj-8IX">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3k9-ik-WIf">
+                                <rect key="frame" x="258" y="285" width="84" height="30"/>
+                                <state key="normal" title="Open Image">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="openImage:" destination="oam-Ti-ubu" eventType="touchUpInside" id="hVq-88-Y4c"/>
+                                    <action selector="openImage:" destination="hJu-qU-eYQ" eventType="touchUpInside" id="lFs-16-dz4"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="3k9-ik-WIf" firstAttribute="centerX" secondItem="T8y-kj-8IX" secondAttribute="centerX" id="WaD-bg-7DF"/>
+                            <constraint firstItem="3k9-ik-WIf" firstAttribute="centerY" secondItem="T8y-kj-8IX" secondAttribute="centerY" id="mvl-qX-cDr"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="QSH-xK-lcY">
+                        <barButtonItem key="leftBarButtonItem" title="Close" id="fSf-XJ-lYH">
+                            <connections>
+                                <action selector="close:" destination="oam-Ti-ubu" id="VZx-hM-cFy"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="uQ8-zD-8Hk" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1289" y="-585"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="mh1-z2-8ZB">
             <objects>
@@ -291,6 +352,24 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="05x-RK-Jls" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="477" y="2229"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Nk4-Gi-3of">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Ndg-rS-gmV" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="IoZ-tN-8S2">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="oam-Ti-ubu" kind="relationship" relationship="rootViewController" id="wgv-Ju-Luy"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="KUg-TA-hQd" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="477" y="-585"/>
         </scene>
     </scenes>
 </document>

--- a/Example/Agrume Example/SingleImageModalViewController.swift
+++ b/Example/Agrume Example/SingleImageModalViewController.swift
@@ -1,0 +1,20 @@
+//
+//  SingleImageModalViewController.swift
+//  Agrume Example
+//
+
+import UIKit
+import Agrume
+
+final class SingleImageModalViewController: UIViewController {
+
+    @IBAction func openImage(sender: AnyObject) {
+        let agrume = Agrume(image: UIImage(named: "MapleBacon")!)
+        agrume.showFrom(self, backgroundSnapshotVC: self.navigationController)
+    }
+
+    @IBAction func close(sender: AnyObject) {
+        self.presentingViewController?.dismissViewControllerAnimated(true, completion: .None)
+    }
+
+}


### PR DESCRIPTION
Without this change, presenting from a modally presented view controller will
snapshot the root view which is unexpected(to me at least).

Ideally we could think through this a bit more and have infer the correct
behavior in the most common cases. But this allows someone to manually set
the correct one without breaking existing behavior for anyone.

### [Video of before and after behavior](http://i.imgur.com/Oek6AvL.gifv)