### PR TITLE
Migrate exmaple project to Swift 3 + minor improvements

### DIFF
--- a/Agrume.xcodeproj/project.pbxproj
+++ b/Agrume.xcodeproj/project.pbxproj
@@ -177,14 +177,16 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Schnaub;
 				TargetAttributes = {
 					F2A51FED1B10E00700924912 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
 					};
 					F2A51FF81B10E00700924912 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -268,8 +270,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -317,8 +321,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -338,6 +344,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -349,6 +356,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -360,6 +368,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -367,6 +376,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -377,6 +387,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.schnaub.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -397,6 +408,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.schnaub.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -412,6 +424,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.schnaub.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Agrume.xcodeproj/xcshareddata/xcschemes/Agrume.xcscheme
+++ b/Agrume.xcodeproj/xcshareddata/xcschemes/Agrume.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -184,7 +184,7 @@ public final class Agrume: UIViewController {
 
   fileprivate var initialOrientation: UIDeviceOrientation!
 
-  public func showFrom(_ viewController: UIViewController, backgroundSnapshotVC: UIViewController? = .none) {
+  public func showFrom(_ viewController: UIViewController, backgroundSnapshotVC: UIViewController? = nil) {
     backgroundSnapshot = (backgroundSnapshotVC ?? viewControllerForSnapshot(fromViewController: viewController))?.view.snapshot()
     view.frame = frameForCurrentDeviceOrientation()
     view.isUserInteractionEnabled = false

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -353,7 +353,7 @@ extension Agrume: UICollectionViewDataSource {
                                                                      for: indexPath) as! AgrumeCell
 
     if let images = self.images {
-      cell.image = images[(indexPath as NSIndexPath).row]
+      cell.image = images[indexPath.row]
     } else if let imageURLs = self.imageURLs {
       spinner.alpha = 1
       let completion: DownloadCompletion = { [weak self] image in
@@ -362,15 +362,15 @@ extension Agrume: UICollectionViewDataSource {
       }
 
       if let download = download {
-        download(imageURLs[(indexPath as NSIndexPath).row], completion)
+        download(imageURLs[indexPath.row], completion)
       } else if let download = AgrumeServiceLocator.shared.downloadHandler {
-        download(imageURLs[(indexPath as NSIndexPath).row], completion)
+        download(imageURLs[indexPath.row], completion)
       } else {
-        downloadImage(imageURLs[(indexPath as NSIndexPath).row], completion: completion)
+        downloadImage(imageURLs[indexPath.row], completion: completion)
       }
 		} else if let dataSource = self.dataSource {
 			spinner.alpha = 1
-			let index = (indexPath as NSIndexPath).row
+			let index = indexPath.row
 			
         dataSource.image(forIndex: index) { [weak self] image in
         DispatchQueue.main.async {
@@ -399,7 +399,7 @@ extension Agrume: UICollectionViewDelegate {
 
   public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell,
                              forItemAt indexPath: IndexPath) {
-    didScroll?((indexPath as NSIndexPath).row)
+    didScroll?(indexPath.row)
 		
 		if let dataSource = self.dataSource {
       let collectionViewCount = collectionView.numberOfItems(inSection: 0)
@@ -408,10 +408,10 @@ extension Agrume: UICollectionViewDelegate {
       // if dataSource hasn't changed the number of images then there is no need to reload (we assume that the same number shall result in the same data)
 			guard collectionViewCount != dataSourceCount else { return }
 			
-			if (indexPath as NSIndexPath).row >= dataSourceCount { // if the dataSource number of images has been decreased and we got out of bounds
+			if indexPath.row >= dataSourceCount { // if the dataSource number of images has been decreased and we got out of bounds
 				showImage(atIndex: dataSourceCount - 1)
 				reload()
-			} else if (indexPath as NSIndexPath).row == collectionViewCount - 1 { // if we are at the last element of the collection but we are not out of bounds
+			} else if indexPath.row == collectionViewCount - 1 { // if we are at the last element of the collection but we are not out of bounds
 				reload()
 			}
 		}

--- a/Agrume/AgrumeServiceLocator.swift
+++ b/Agrume/AgrumeServiceLocator.swift
@@ -17,7 +17,7 @@ public class AgrumeServiceLocator {
   /// by passing in a different handler for said call.
   ///
   /// – Parameter handler: The download handler
-  public func setDownloadHandler(handler: DownloadHandler) {
+  public func setDownloadHandler(_ handler: DownloadHandler) {
     downloadHandler = handler
   }
   

--- a/Agrume/ImageDownloader.swift
+++ b/Agrume/ImageDownloader.swift
@@ -15,7 +15,8 @@ final class ImageDownloader {
         completion(nil)
         return
       }
-      DispatchQueue.global(priority: DispatchQueue.GlobalQueuePriority.high).async {
+
+      DispatchQueue.global(qos: .userInteractive).async {
         if let data = data, let image = UIImage(data: data) {
           DispatchQueue.main.async {
               completion(image)

--- a/AgrumeTests/AgrumeServiceLocatorTests.swift
+++ b/AgrumeTests/AgrumeServiceLocatorTests.swift
@@ -13,7 +13,7 @@ class AgrumeServiceLocatorTests: XCTestCase {
   override func setUp() {
     super.setUp()
     
-    agrume = Agrume(imageURL: NSURL(string: "https://dl.dropboxusercontent.com/u/512759/MapleBacon.png")!)
+    agrume = Agrume(imageURL: URL(string: "https://dl.dropboxusercontent.com/u/512759/MapleBacon.png")!)
   }
   
   override func tearDown() {

--- a/Example/Agrume Example.xcodeproj/project.pbxproj
+++ b/Example/Agrume Example.xcodeproj/project.pbxproj
@@ -213,14 +213,16 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Schnaub;
 				TargetAttributes = {
 					F2A520141B130C7E00924912 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
 					};
 					F2A520291B130C7E00924912 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
 						TestTargetID = F2A520141B130C7E00924912;
 					};
 				};
@@ -359,8 +361,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -404,8 +408,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -437,6 +443,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.schnaub.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -448,6 +455,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.schnaub.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -467,6 +475,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.schnaub.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Agrume Example.app/Agrume Example";
 			};
 			name = Debug;
@@ -483,6 +492,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.schnaub.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Agrume Example.app/Agrume Example";
 			};
 			name = Release;

--- a/Example/Agrume Example/AppDelegate.swift
+++ b/Example/Agrume Example/AppDelegate.swift
@@ -10,7 +10,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject:AnyObject]?) -> Bool {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]?) -> Bool {
         return true
     }
 

--- a/Example/Agrume Example/MultipleImagesCollectionViewController.swift
+++ b/Example/Agrume Example/MultipleImagesCollectionViewController.swift
@@ -8,43 +8,42 @@ import Agrume
 
 final class MultipleImagesCollectionViewController: UICollectionViewController {
 
-    private let identifier = "Cell"
+  private let identifier = "Cell"
 
-    private let images = [
-            UIImage(named: "MapleBacon")!,
-            UIImage(named: "EvilBacon")!
-    ]
+  private let images = [
+    UIImage(named: "MapleBacon")!,
+    UIImage(named: "EvilBacon")!
+  ]
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+  override func viewDidLoad() {
+    super.viewDidLoad()
 
-        let layout = collectionView?.collectionViewLayout as! UICollectionViewFlowLayout
-        layout.itemSize = CGSize(width: CGRectGetWidth(view.bounds), height: CGRectGetHeight(view.bounds))
+    let layout = collectionView?.collectionViewLayout as! UICollectionViewFlowLayout
+    layout.itemSize = CGSize(width: view.bounds.width, height: view.bounds.height)
+  }
+
+  // MARK: UICollectionViewDataSource
+
+  override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return images.count
+  }
+
+  override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath) as! DemoCell
+    cell.imageView.image = images[indexPath.row]
+    return cell
+  }
+
+  // MARK: UICollectionViewDelegate
+
+  override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    let agrume = Agrume(images: images, startIndex: indexPath.row, backgroundBlurStyle: .light)
+    agrume.didScroll = { [unowned self] index in
+      self.collectionView?.scrollToItem(at: IndexPath(row: index, section: 0),
+                                        at: [],
+                                        animated: false)
     }
-
-    // MARK: UICollectionViewDataSource
-
-    override func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return images.count
-    }
-
-    override func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCellWithReuseIdentifier(identifier, forIndexPath: indexPath) as! DemoCell
-        cell.imageView.image = images[indexPath.row]
-        return cell
-    }
-
-    // MARK: UICollectionViewDelegate
-
-    override func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
-        let agrume = Agrume(images: images, startIndex: indexPath.row, backgroundBlurStyle: .Light)
-        agrume.didScroll = {
-            [unowned self] index in
-            self.collectionView?.scrollToItemAtIndexPath(NSIndexPath(forRow: index, inSection: 0),
-                    atScrollPosition: [],
-                    animated: false)
-        }
-        agrume.showFrom(self)
-    }
+    agrume.showFrom(self)
+  }
 
 }

--- a/Example/Agrume Example/MultipleURLsCollectionViewController.swift
+++ b/Example/Agrume Example/MultipleURLsCollectionViewController.swift
@@ -8,49 +8,49 @@ import Agrume
 
 final class MultipleURLsCollectionViewController: UICollectionViewController {
 
-    private let identifier = "Cell"
+  private let identifier = "Cell"
 
-    private struct ImageWithURL {
-        let image: UIImage
-        let URL: NSURL
+  private struct ImageWithURL {
+    let image: UIImage
+    let url: URL
+  }
+
+  private let images = [
+    ImageWithURL(image: UIImage(named: "MapleBacon")!, url: URL(string: "https://dl.dropboxusercontent.com/u/512759/MapleBacon.png")!),
+    ImageWithURL(image: UIImage(named: "EvilBacon")!, url: URL(string: "https://dl.dropboxusercontent.com/u/512759/EvilBacon.png")!)
+  ]
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    let layout = collectionView?.collectionViewLayout as! UICollectionViewFlowLayout
+    layout.itemSize = CGSize(width: view.bounds.width, height: view.bounds.height)
+  }
+
+  // MARK: UICollectionViewDataSource
+
+  override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return images.count
+  }
+
+  override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath) as! DemoCell
+    cell.imageView.image = images[indexPath.row].image
+    return cell
+  }
+
+  // MARK: UICollectionViewDelegate
+
+  override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    let URLs = images.map { $0.url }
+    let agrume = Agrume(imageURLs: URLs, startIndex: indexPath.row, backgroundBlurStyle: .extraLight)
+    agrume.didScroll = {
+      [unowned self] index in
+      self.collectionView?.scrollToItem(at: IndexPath(row: index, section: 0),
+                                        at: [],
+                                        animated: false)
     }
-
-    private let images = [
-        ImageWithURL(image: UIImage(named: "MapleBacon")!, URL: NSURL(string: "https://dl.dropboxusercontent.com/u/512759/MapleBacon.png")!),
-        ImageWithURL(image: UIImage(named: "EvilBacon")!, URL: NSURL(string: "https://dl.dropboxusercontent.com/u/512759/EvilBacon.png")!)
-    ]
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        let layout = collectionView?.collectionViewLayout as! UICollectionViewFlowLayout
-        layout.itemSize = CGSize(width: CGRectGetWidth(view.bounds), height: CGRectGetHeight(view.bounds))
-    }
-
-    // MARK: UICollectionViewDataSource
-
-    override func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return images.count
-    }
-
-    override func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCellWithReuseIdentifier(identifier, forIndexPath: indexPath) as! DemoCell
-        cell.imageView.image = images[indexPath.row].image
-        return cell
-    }
-
-    // MARK: UICollectionViewDelegate
-
-    override func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
-        let URLs = images.map { $0.URL }
-        let agrume = Agrume(imageURLs: URLs, startIndex: indexPath.row, backgroundBlurStyle: .ExtraLight)
-        agrume.didScroll = {
-            [unowned self] index in
-            self.collectionView?.scrollToItemAtIndexPath(NSIndexPath(forRow: index, inSection: 0),
-                    atScrollPosition: [],
-                    animated: false)
-        }
-        agrume.showFrom(self)
-    }
+    agrume.showFrom(self)
+  }
 
 }

--- a/Example/Agrume Example/SingleImageModalViewController.swift
+++ b/Example/Agrume Example/SingleImageModalViewController.swift
@@ -22,7 +22,7 @@ final class SingleImageModalViewController: UIViewController {
   }
 
   @IBAction func close(_ sender: AnyObject) {
-      presentingViewController?.dismiss(animated: true, completion: .none)
+      presentingViewController?.dismiss(animated: true, completion: nil)
   }
 
 }

--- a/Example/Agrume Example/SingleImageModalViewController.swift
+++ b/Example/Agrume Example/SingleImageModalViewController.swift
@@ -11,18 +11,18 @@ final class SingleImageModalViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    navigationController?.navigationBar.barTintColor = .redColor()
+    navigationController?.navigationBar.barTintColor = .red
   }
   
-  @IBAction func openImage(sender: AnyObject) {
+  @IBAction func openImage(_ sender: AnyObject) {
     let agrume = Agrume(image: UIImage(named: "MapleBacon")!)
     agrume.showFrom(self)
     // Optionally pass in a custom background snapshot VC but the library should pick the correct one for you
 //  agrume.showFrom(self, backgroundSnapshotVC: navigationController)
   }
 
-  @IBAction func close(sender: AnyObject) {
-      presentingViewController?.dismissViewControllerAnimated(true, completion: .None)
+  @IBAction func close(_ sender: AnyObject) {
+      presentingViewController?.dismiss(animated: true, completion: .none)
   }
 
 }

--- a/Example/Agrume Example/SingleImageViewController.swift
+++ b/Example/Agrume Example/SingleImageViewController.swift
@@ -8,7 +8,7 @@ import Agrume
 
 final class SingleImageViewController: UIViewController {
 
-    @IBAction func openImage(sender: AnyObject) {
+    @IBAction func openImage(_ sender: AnyObject) {
         let agrume = Agrume(image: UIImage(named: "MapleBacon")!)
         agrume.showFrom(self)
     }

--- a/Example/Agrume Example/SingleURLViewController.swift
+++ b/Example/Agrume Example/SingleURLViewController.swift
@@ -8,9 +8,9 @@ import Agrume
 
 final class SingleURLViewController: UIViewController {
 
-    @IBAction func openURL(sender: AnyObject) {
-        let agrume = Agrume(imageURL: NSURL(string: "https://dl.dropboxusercontent.com/u/512759/MapleBacon.png")!,
-                backgroundBlurStyle: .Light)
+    @IBAction func openURL(_ sender: AnyObject) {
+        let agrume = Agrume(imageURL: URL(string: "https://dl.dropboxusercontent.com/u/512759/MapleBacon.png")!,
+                backgroundBlurStyle: .light)
         agrume.showFrom(self)
     }
 

--- a/Example/Agrume ExampleTests/Agrume_ExampleTests.swift
+++ b/Example/Agrume ExampleTests/Agrume_ExampleTests.swift
@@ -28,7 +28,7 @@ class Agrume_ExampleTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock() {
+        measure() {
             // Put the code you want to measure the time of here.
         }
     }

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ An iOS image viewer written in Swift with support for multiple images.
 
 ## Requirements
 
-- Swift 2.2
+- Swift 3.0
 - iOS 8.0+
-- Xcode 7+
+- Xcode 8+
 
 ## Installation
 
@@ -41,7 +41,7 @@ For just a single image it's as easy as
 ```swift
 import Agrume
 
-@IBAction func openImage(sender: AnyObject) {
+@IBAction func openImage(_ sender: AnyObject) {
   if let image = UIImage(named: "…") {
 	let agrume = Agrume(image: image)
 	agrume.showFrom(self)	
@@ -56,11 +56,11 @@ You can also pass in an `NSURL` and Agrume will take care of the download for yo
 If you're displaying a `UICollectionView` and want to add support for zooming, you can also call Agrume with an array of either images or URLs.
 
 ```swift
-let agrume = Agrume(images: images, startIndex: indexPath.row, backgroundBlurStyle: .Light)
+let agrume = Agrume(images: images, startIndex: indexPath.row, backgroundBlurStyle: .light)
 agrume.didScroll = { [unowned self] index in
-  self.collectionView?.scrollToItemAtIndexPath(NSIndexPath(forRow: index, inSection: 0),
-    											atScrollPosition: .allZeros,
-									            animated: false)
+  self.collectionView?.scrollToItem(at: IndexPath(row: index, section: 0),
+                                    at: [],
+                                    animated: false)
 }
 agrume.showFrom(self)
 ```
@@ -75,15 +75,14 @@ If you want to take control of downloading images (e.g. for caching), you can al
 import Agrume
 import MapleBacon
 
-@IBAction func openURL(sender: AnyObject) {
-  let agrume = Agrume(imageURL: NSURL(string: "https://dl.dropboxusercontent.com/u/512759/MapleBacon.png")!, backgroundBlurStyle: .Light)
+@IBAction func openURL(_ sender: AnyObject) {
+  let agrume = Agrume(imageURL: URL(string: "https://dl.dropboxusercontent.com/u/512759/MapleBacon.png")!, backgroundBlurStyle: .light)
 	agrume.download = { url, completion in
-	  let manager = ImageManager.sharedManager
-	  manager.downloadImageAtURL(url) { imageInstance, error in
-		if error == nil {
-		  completion(image: imageInstance.image)
+	  ImageDownloader.downloadImage(url) { image in
+		if let image = image {
+		  completion(image)
 		} else {
-		  completion(image: nil)
+		  completion(nil)
 		}
 	}
   }
@@ -137,7 +136,7 @@ You can customize the status bar appearance when displaying the zoomed in view. 
 
 ```swift
 let agrume = Agrume(image: image)
-agrume.statusBarStyle = .LightContent
+agrume.statusBarStyle = .lightContent
 agrume.showFrom(self)
 ```
 


### PR DESCRIPTION
In this pull request:

- Example project and test suite migrated to Swift 3
- README.md updated according to language standard changes
- `(indexPath as NSIndexPath)` replaced with just `indexPath`
- Using `nil` literal instead of `.none` case