### PR TITLE
Added @escaping

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -35,7 +35,7 @@ public final class Agrume: UIViewController {
     
   public var didDismiss: (() -> Void)?
   public var didScroll: ((_ index: Int) -> Void)?
-  public var download: ((_ url: URL, _ completion: DownloadCompletion) -> Void)?
+  public var download: ((_ url: URL, _ completion: @escaping DownloadCompletion) -> Void)?
   public var statusBarStyle: UIStatusBarStyle? {
     didSet {
       setNeedsStatusBarAppearanceUpdate()


### PR DESCRIPTION
Fixed custom download handler.
Fixed warning message in Xcode 8.

```
`import Agrume
import MapleBacon

@IBAction func openURL(_ sender: AnyObject) {
  let agrume = Agrume(imageUrl: URL(string: "https://dl.dropboxusercontent.com/u/512759/MapleBacon.png")!, backgroundBlurStyle: .light)
    agrume.download = { url, completion in
      ImageDownloader.downloadImage(url) { image in
        if let image = image {
          completion(image)
        } else {
          completion(nil)
        }
    }
  }
  agrume.showFrom(self)
}`
```
