### PR TITLE
Datasource crash fix

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -573,6 +573,9 @@ extension Agrume: AgrumeCellDelegate {
     if let images = images, !images.isEmpty {
       return images.count == 1
     }
+    if let dataSource = dataSource {
+      return dataSource.numberOfImages == 1
+    }
     return imageUrls.count == 1
   }
   

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -451,7 +451,6 @@ extension Agrume: UICollectionViewDataSource {
 			
       dataSource.image(forIndex: index) { [weak self] image in
         DispatchQueue.main.async {
-          guard collectionView.indexPathsForVisibleItems.contains(indexPath) else { return }
           cell.image = image
           self?.spinner.alpha = 0
         }

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -499,10 +499,8 @@ extension Agrume: UICollectionViewDelegate {
 			
 			if isIndexPathOutOfBounds(indexPath, count: dataSourceCount) {
 				showImage(atIndex: dataSourceCount - 1)
-				reload()
-			} else if isLastElement(atIndexPath: indexPath, count: collectionViewCount - 1) {
-				reload()
 			}
+      reload()
 		}
   }
   


### PR DESCRIPTION
There is a crash, when using Agrume with a dataSource in Agrume.swift, implementation of the AgrumeCell.swift protocol method: 
```
func isSingleImageMode() -> Bool {
...
}
```

Also, fixed a bug, caused by the line 

`guard collectionView.indexPathsForVisibleItems.contains(indexPath) else { return }`
in
```
public func collectionView(_ collectionView: UICollectionView,
                             cellForItemAt indexPath: IndexPath) -> UICollectionViewCell
```
method. It was preventing the images with the index >=2 from appearing.
