### PR TITLE
Fix build error caused by SwiftyGif update

### DIFF
--- a/Agrume/ImageDownloader.swift
+++ b/Agrume/ImageDownloader.swift
@@ -20,7 +20,7 @@ final class ImageDownloader {
       }
       guard let data = data, error == nil else { return }
       if isAnimatedImage(data) {
-        image = UIImage(gifData: data)
+        image = try? UIImage(gifData: data)
       } else {
         image = UIImage(data: data)
       }


### PR DESCRIPTION
Latest [SwiftyGif](https://github.com/kirualex/SwiftyGif) master repo update causes a build failure on Cocoapods version 5.3.0

This commit updates SwiftyGif submodule and fixes the build error.