### PR TITLE
Fix blurContainerView's size, it was hidden

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -132,14 +132,15 @@ public final class Agrume: UIViewController {
   private var _blurContainerView: UIView?
   private var blurContainerView: UIView {
     if _blurContainerView == nil {
-      let view = UIView()
-      view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      let blurContainerView = UIView()
+      blurContainerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
       if case .colored(let color) = background {
-        view.backgroundColor = color
+        blurContainerView.backgroundColor = color
       } else {
-        view.backgroundColor = .clear
+        blurContainerView.backgroundColor = .clear
       }
-      _blurContainerView = view
+      blurContainerView.frame = view.frame
+      _blurContainerView = blurContainerView
     }
     return _blurContainerView!
   }


### PR DESCRIPTION
Right now the blurContainerView is not visible, either in `.blurred` and `.colored` modes.
To reproduce just open the "Single Image (Background Color)" example which is meant to display a black background.

Before:
![Simulator Screen Shot - iPhone Xʀ - 2019-08-29 at 12 57 07](https://user-images.githubusercontent.com/531755/63934964-c99fb600-ca5c-11e9-99c0-32f89a40a1c5.png)

After:
![Simulator Screen Shot - iPhone Xʀ - 2019-08-29 at 12 57 56](https://user-images.githubusercontent.com/531755/63934971-cefd0080-ca5c-11e9-8121-8830a3770d35.png)
