### PR TITLE
handle init safe area

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -173,6 +173,9 @@ public final class Agrume: UIViewController {
       collectionView.backgroundColor = .clear
       collectionView.delaysContentTouches = false
       collectionView.showsHorizontalScrollIndicator = false
+      if #available(iOS 11.0, *) {
+        collectionView.contentInsetAdjustmentBehavior = .never
+      }
       _collectionView = collectionView
     }
     return _collectionView!


### PR DESCRIPTION
I found that in iOS 11 UIScrollViewContentInsetAdjustmentBehavior.always includes safe area layout guide and apply these margins as insets, so tried .never it worked ))