### PR TITLE
Improving didScroll when Swiping Left & Right

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -371,10 +371,11 @@ extension Agrume: UICollectionViewDataSource {
 extension Agrume: UICollectionViewDelegate {
 
   public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    guard let indexPath = collectionView.indexPathsForVisibleItems.first else {
-      return
-    }
-    didScroll?(indexPath.item)
+    let visibleRect    = CGRect(origin: collectionView.contentOffset, size: collectionView.bounds.size)
+    let visiblePoint   = CGPoint(x: visibleRect.midX, y: visibleRect.midY)
+    
+    guard let visibleIndexPath: IndexPath = collectionView.indexPathForItem(at: visiblePoint) else { return }
+    didScroll?(visibleIndexPath.item)
   }
 
 }


### PR DESCRIPTION
indexPathsForVisibleItems.first works fine when you swipe left, but when you swipe right the .first is wrong.

Check the video https://streamable.com/54v1o for reproduce.
This commit will return the correct index when scrolling 