### PR TITLE
added savePhotoOnLongPress function

### DIFF
--- a/Agrume.xcodeproj/project.pbxproj
+++ b/Agrume.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		833C23CA23CC800800F689E2 /* AgrumePhotoLibraryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833C23C923CC800800F689E2 /* AgrumePhotoLibraryHelper.swift */; };
 		94318E541D32612D0096215A /* AgrumeServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94318E531D32612D0096215A /* AgrumeServiceLocator.swift */; };
 		F2539BA120F22E7700062C80 /* AgrumeOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2539BA020F22E7700062C80 /* AgrumeOverlayView.swift */; };
 		F2609E23209F047200E0E93D /* AgrumeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2609E22209F047200E0E93D /* AgrumeDataSource.swift */; };
@@ -48,6 +49,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		833C23C923CC800800F689E2 /* AgrumePhotoLibraryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgrumePhotoLibraryHelper.swift; sourceTree = "<group>"; };
 		94318E531D32612D0096215A /* AgrumeServiceLocator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgrumeServiceLocator.swift; sourceTree = "<group>"; };
 		F2539BA020F22E7700062C80 /* AgrumeOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgrumeOverlayView.swift; sourceTree = "<group>"; };
 		F2609E22209F047200E0E93D /* AgrumeDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgrumeDataSource.swift; sourceTree = "<group>"; };
@@ -128,6 +130,7 @@
 				94318E531D32612D0096215A /* AgrumeServiceLocator.swift */,
 				F2609E27209F2BC600E0E93D /* Configuration.swift */,
 				F2EE29AD209F31B800F281A2 /* Foundation+Agrume.swift */,
+				833C23C923CC800800F689E2 /* AgrumePhotoLibraryHelper.swift */,
 				F2DC79D51B170C4B00818A8C /* ImageDownloader.swift */,
 				F2A51FF11B10E00700924912 /* Supporting Files */,
 				F2609E29209F2E0200E0E93D /* UIKit+Agrume.swift */,
@@ -327,6 +330,7 @@
 				F2609E2A209F2E0200E0E93D /* UIKit+Agrume.swift in Sources */,
 				F2609E28209F2BC600E0E93D /* Configuration.swift in Sources */,
 				F2EE29AE209F31B800F281A2 /* Foundation+Agrume.swift in Sources */,
+				833C23CA23CC800800F689E2 /* AgrumePhotoLibraryHelper.swift in Sources */,
 				F2F24F9423BB3BBE005AA731 /* With.swift in Sources */,
 				F2DC79D61B170C4B00818A8C /* ImageDownloader.swift in Sources */,
 				F2539BA120F22E7700062C80 /* AgrumeOverlayView.swift in Sources */,

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -18,7 +18,8 @@ public final class Agrume: UIViewController {
   public typealias DownloadCompletion = (_ image: UIImage?) -> Void
 
   /// Optional closure to call when user long pressed on an image
-public var onLongPress: ((UIImage?, UIViewController) -> Void)?  /// Optional closure to call whenever Agrume is about to dismiss.
+  public var onLongPress: ((UIImage?, UIViewController) -> Void)?
+  /// Optional closure to call whenever Agrume is about to dismiss.
   public var willDismiss: (() -> Void)?
   /// Optional closure to call whenever Agrume is dismissed.
   public var didDismiss: (() -> Void)?

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -18,19 +18,12 @@ public final class Agrume: UIViewController {
   public typealias DownloadCompletion = (_ image: UIImage?) -> Void
 
   /// Optional closure to call when user long pressed on an image
-  public var onLongPress: (() -> Void)?
-  /// Optional closure to call whenever Agrume is about to dismiss.
+public var onLongPress: ((UIImage?, UIViewController) -> Void)?  /// Optional closure to call whenever Agrume is about to dismiss.
   public var willDismiss: (() -> Void)?
   /// Optional closure to call whenever Agrume is dismissed.
   public var didDismiss: (() -> Void)?
   /// Optional closure to call whenever Agrume scrolls to the next image in a collection. Passes the "page" index
   public var didScroll: ((_ index: Int) -> Void)?
-  /// Optional closure to call whenever savePhotoOnLongPress was successfull.
-  public var photoSavedToLibrary: ((_ error: Error?) -> Void)?
-  /// Alert title text to save photo to library
-  public var photoSaveToLibraryTitle = "Save Photo"
-  /// Alert cancel text to save photo to library
-  public var photoSaveToLibraryCancel = "Cancel"
   /// An optional download handler. Passed the URL that is supposed to be loaded. Call the completion with the image
   /// when the download is done.
   public var download: ((_ url: URL, _ completion: @escaping DownloadCompletion) -> Void)?
@@ -265,31 +258,6 @@ public final class Agrume: UIViewController {
   func didLongPress(_ gesture: UIGestureRecognizer) {
     guard gesture.state == .began else { return }
     onLongPress?()
-  }
-  
-  @objc
-  func image(_ image: UIImage, didFinishSavingWithError error: NSError?, contextInfo: UnsafeRawPointer) {
-    photoSavedToLibrary?(error)
-  }
-
-  /// Save the current photo shown in the user's photo library
-  /// Make sure to have NSPhotoLibraryUsageDescription (ios 10) and NSPhotoLibraryAddUsageDescription (ios 11+) in your info.plist
-  public func savePhotoOnLongPress() {
-      guard let image = images[currentIndex].image else { return }
-      
-      let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-      alert.popoverPresentationController?.sourceView = self.view
-      alert.popoverPresentationController?.permittedArrowDirections = .up
-      let alertPosition = CGRect(x: view.bounds.midX, y: view.bounds.maxY - view.bounds.midY / 2, width: 0, height: 0)
-      alert.popoverPresentationController?.sourceRect = alertPosition
-
-      alert.addAction(UIAlertAction(title: photoSaveToLibraryTitle, style: .default, handler: { _ in
-          UIImageWriteToSavedPhotosAlbum(image, self,
-                                         #selector(self.image(_:didFinishSavingWithError:contextInfo:)), nil)
-      }))
-      alert.addAction(UIAlertAction(title: photoSaveToLibraryCancel, style: .cancel, handler: nil))
-
-      present(alert, animated: true)
   }
 
   private func addSubviews() {

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -261,12 +261,14 @@ public final class Agrume: UIViewController {
     }
   }
 
-  @objc func didLongPress(_ gesture: UIGestureRecognizer) {
+  @objc
+  func didLongPress(_ gesture: UIGestureRecognizer) {
     guard gesture.state == .began else { return }
     onLongPress?()
   }
   
-  @objc func image(_ image: UIImage, didFinishSavingWithError error: NSError?, contextInfo: UnsafeRawPointer) {
+  @objc
+  func image(_ image: UIImage, didFinishSavingWithError error: NSError?, contextInfo: UnsafeRawPointer) {
     photoSavedToLibrary?(error)
   }
 
@@ -277,6 +279,9 @@ public final class Agrume: UIViewController {
       
       let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
       alert.popoverPresentationController?.sourceView = self.view
+      alert.popoverPresentationController?.permittedArrowDirections = .up
+      let alertPosition = CGRect(x: view.bounds.midX, y: view.bounds.maxY - view.bounds.midY / 2, width: 0, height: 0)
+      alert.popoverPresentationController?.sourceRect = alertPosition
 
       alert.addAction(UIAlertAction(title: photoSaveToLibraryTitle, style: .default, handler: { _ in
           UIImageWriteToSavedPhotosAlbum(image, self,

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -256,7 +256,9 @@ public var onLongPress: ((UIImage?, UIViewController) -> Void)?  /// Optional cl
 
   @objc
   func didLongPress(_ gesture: UIGestureRecognizer) {
-    guard gesture.state == .began else { return }
+    guard gesture.state == .began else {
+      return
+    }
     onLongPress?()
   }
 

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -259,7 +259,7 @@ public var onLongPress: ((UIImage?, UIViewController) -> Void)?  /// Optional cl
     guard gesture.state == .began else {
       return
     }
-    onLongPress?()
+    onLongPress?(images?[currentIndex].image, self)
   }
 
   private func addSubviews() {

--- a/Agrume/AgrumePhotoLibraryHelper.swift
+++ b/Agrume/AgrumePhotoLibraryHelper.swift
@@ -1,0 +1,54 @@
+//
+//  AgrumePhotoLibraryHelper.swift
+//  Agrume
+//
+//  Created by Alexandros Lykesas on 13/1/20.
+//  Copyright © 2020 Schnaub. All rights reserved.
+//
+
+import UIKit
+
+public final class AgrumePhotoLibraryHelper: NSObject {
+
+  private let saveButtonTitle: String
+  private let cancelButtonTitle: String
+  private let saveToLibraryHandler: (_ error: Error?) -> Void
+
+  /// Initialize photo library helper
+  ///
+  /// - Parameters:
+  ///   - saveButtonTitle: Title text to save photo to library
+  ///   - cancelButtonTitle: Cancel text to save photo to library
+  ///   - saveToLibraryHandler: saveToLibraryHandler to notify the user if it was successfull.
+  public init(saveButtonTitle: String, cancelButtonTitle: String, saveToLibraryHandler: @escaping (_ error: Error?) -> Void) {
+    self.saveButtonTitle = saveButtonTitle
+    self.cancelButtonTitle = cancelButtonTitle
+    self.saveToLibraryHandler = saveToLibraryHandler
+  }
+
+  /// Save the current photo shown in the user's photo library using Long Press Gesture
+  /// Make sure to have NSPhotoLibraryUsageDescription (ios 10) and NSPhotoLibraryAddUsageDescription (ios 11+) in your info.plist
+  public func makeSaveToLibraryLongPressGesture(for image: UIImage?, viewController: UIViewController) {
+    guard let image = image else {
+      return
+    }
+    let view = viewController.view!
+    let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+    alert.popoverPresentationController?.sourceView = view
+    alert.popoverPresentationController?.permittedArrowDirections = .up
+    let alertPosition = CGRect(x: view.bounds.midX, y: view.bounds.maxY - view.bounds.midY / 2, width: 0, height: 0)
+    alert.popoverPresentationController?.sourceRect = alertPosition
+  
+    alert.addAction(UIAlertAction(title: saveButtonTitle, style: .default) { _ in
+      UIImageWriteToSavedPhotosAlbum(image, self, #selector(self.image), nil)
+    })
+    alert.addAction(UIAlertAction(title: cancelButtonTitle, style: .cancel, handler: nil))
+  
+    viewController.present(alert, animated: true)
+  }
+  
+  @objc
+  private func image(_ image: UIImage, didFinishSavingWithError error: NSError?, contextInfo: UnsafeRawPointer) {
+    saveToLibraryHandler(error)
+  }
+}

--- a/Agrume/AgrumePhotoLibraryHelper.swift
+++ b/Agrume/AgrumePhotoLibraryHelper.swift
@@ -1,8 +1,4 @@
 //
-//  AgrumePhotoLibraryHelper.swift
-//  Agrume
-//
-//  Created by Alexandros Lykesas on 13/1/20.
 //  Copyright © 2020 Schnaub. All rights reserved.
 //
 

--- a/Example/Agrume Example/Info.plist
+++ b/Example/Agrume Example/Info.plist
@@ -41,5 +41,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+  <key>NSPhotoLibraryAddUsageDescription</key>
+  <string>Photos access is required to save photos in your library</string>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>Photos access is required to save photos in your library</string>
 </dict>
 </plist>

--- a/Example/Agrume Example/MultipleImagesCollectionViewController.swift
+++ b/Example/Agrume Example/MultipleImagesCollectionViewController.swift
@@ -40,7 +40,7 @@ final class MultipleImagesCollectionViewController: UICollectionViewController {
       self.collectionView?.scrollToItem(at: IndexPath(item: index, section: 0), at: [], animated: false)
     }
     let helper = makeHelper()
-    agrume.onLongPress = helper.makeLongPressGesture
+    agrume.onLongPress = helper.makeSaveToLibraryLongPressGesture
     agrume.show(from: self)
   }
   

--- a/Example/Agrume Example/MultipleImagesCollectionViewController.swift
+++ b/Example/Agrume Example/MultipleImagesCollectionViewController.swift
@@ -39,15 +39,21 @@ final class MultipleImagesCollectionViewController: UICollectionViewController {
     agrume.didScroll = { [unowned self] index in
       self.collectionView?.scrollToItem(at: IndexPath(item: index, section: 0), at: [], animated: false)
     }
-    agrume.onLongPress = agrume.savePhotoOnLongPress
-    agrume.photoSavedToLibrary = { error in
-      if error != nil { // we got back an error!
-        print"Could not save your photo")
-      } else {
-        print("Photo has been saved to your library")
-      }
-    }
+    let helper = makeHelper()
+    agrume.onLongPress = helper.makeLongPressGesture
     agrume.show(from: self)
   }
-
+  
+  private func makeHelper() -> AgrumePhotoLibraryHelper {
+    let saveButtonTitle = NSLocalizedString("Save Photo", comment: "Save Photo")
+    let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel")
+    let helper = AgrumePhotoLibraryHelper(saveButtonTitle: saveButtonTitle, cancelButtonTitle: cancelButtonTitle) { error in
+      guard error == nil else {
+        print("Could not save your photo")
+        return
+      }
+      print("Photo has been saved to your library")
+    }
+    return helper
+  }
 }

--- a/Example/Agrume Example/MultipleImagesCollectionViewController.swift
+++ b/Example/Agrume Example/MultipleImagesCollectionViewController.swift
@@ -39,6 +39,14 @@ final class MultipleImagesCollectionViewController: UICollectionViewController {
     agrume.didScroll = { [unowned self] index in
       self.collectionView?.scrollToItem(at: IndexPath(item: index, section: 0), at: [], animated: false)
     }
+    agrume.onLongPress = agrume.savePhotoOnLongPress
+    agrume.photoSavedToLibrary = { error in
+      if error != nil { // we got back an error!
+        print"Could not save your photo")
+      } else {
+        print("Photo has been saved to your library")
+      }
+    }
     agrume.show(from: self)
   }
 

--- a/Example/Agrume Example/MultipleURLsCollectionViewController.swift
+++ b/Example/Agrume Example/MultipleURLsCollectionViewController.swift
@@ -46,7 +46,14 @@ final class MultipleURLsCollectionViewController: UICollectionViewController {
     agrume.didScroll = { [unowned self] index in
       self.collectionView?.scrollToItem(at: IndexPath(item: index, section: 0), at: [], animated: false)
     }
+    agrume.onLongPress = agrume.savePhotoOnLongPress
+    agrume.photoSavedToLibrary = { error in
+      if error != nil { // we got back an error!
+        print"Could not save your photo")
+      } else {
+        print("Photo has been saved to your library")
+      }
+    }
     agrume.show(from: self)
   }
-  
 }

--- a/Example/Agrume Example/MultipleURLsCollectionViewController.swift
+++ b/Example/Agrume Example/MultipleURLsCollectionViewController.swift
@@ -47,7 +47,7 @@ final class MultipleURLsCollectionViewController: UICollectionViewController {
       self.collectionView?.scrollToItem(at: IndexPath(item: index, section: 0), at: [], animated: false)
     }
     let helper = makeHelper()
-    agrume.onLongPress = helper.makeLongPressGesture
+    agrume.onLongPress = helper.makeSaveToLibraryLongPressGesture
     agrume.show(from: self)
   }
   

--- a/Example/Agrume Example/MultipleURLsCollectionViewController.swift
+++ b/Example/Agrume Example/MultipleURLsCollectionViewController.swift
@@ -46,14 +46,21 @@ final class MultipleURLsCollectionViewController: UICollectionViewController {
     agrume.didScroll = { [unowned self] index in
       self.collectionView?.scrollToItem(at: IndexPath(item: index, section: 0), at: [], animated: false)
     }
-    agrume.onLongPress = agrume.savePhotoOnLongPress
-    agrume.photoSavedToLibrary = { error in
-      if error != nil { // we got back an error!
-        print"Could not save your photo")
-      } else {
-        print("Photo has been saved to your library")
-      }
-    }
+    let helper = makeHelper()
+    agrume.onLongPress = helper.makeLongPressGesture
     agrume.show(from: self)
+  }
+  
+  private func makeHelper() -> AgrumePhotoLibraryHelper {
+    let saveButtonTitle = NSLocalizedString("Save Photo", comment: "Save Photo")
+    let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel")
+    let helper = AgrumePhotoLibraryHelper(saveButtonTitle: saveButtonTitle, cancelButtonTitle: cancelButtonTitle) { error in
+      guard error == nil else {
+        print("Could not save your photo")
+        return
+      }
+      print("Photo has been saved to your library")
+    }
+    return helper
   }
 }

--- a/Example/Agrume Example/SingeImageBackgroundColorViewController.swift
+++ b/Example/Agrume Example/SingeImageBackgroundColorViewController.swift
@@ -15,7 +15,7 @@ final class SingleImageBackgroundColorViewController: UIViewController {
 
   @IBAction private func openImage(_ sender: Any) {
     let helper = makeHelper()
-    agrume.onLongPress = helper.makeLongPressGesture
+    agrume.onLongPress = helper.makeSaveToLibraryLongPressGesture
     agrume.show(from: self)
   }
   

--- a/Example/Agrume Example/SingeImageBackgroundColorViewController.swift
+++ b/Example/Agrume Example/SingeImageBackgroundColorViewController.swift
@@ -14,8 +14,21 @@ final class SingleImageBackgroundColorViewController: UIViewController {
   }()
 
   @IBAction private func openImage(_ sender: Any) {
-    agrume.onLongPress = agrume.savePhotoOnLongPress
+    let helper = makeHelper()
+    agrume.onLongPress = helper.makeLongPressGesture
     agrume.show(from: self)
   }
   
+  private func makeHelper() -> AgrumePhotoLibraryHelper {
+    let saveButtonTitle = NSLocalizedString("Save Photo", comment: "Save Photo")
+    let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel")
+    let helper = AgrumePhotoLibraryHelper(saveButtonTitle: saveButtonTitle, cancelButtonTitle: cancelButtonTitle) { error in
+      guard error == nil else {
+        print("Could not save your photo")
+        return
+      }
+      print("Photo has been saved to your library")
+    }
+    return helper
+  }
 }

--- a/Example/Agrume Example/SingeImageBackgroundColorViewController.swift
+++ b/Example/Agrume Example/SingeImageBackgroundColorViewController.swift
@@ -14,6 +14,7 @@ final class SingleImageBackgroundColorViewController: UIViewController {
   }()
 
   @IBAction private func openImage(_ sender: Any) {
+    agrume.onLongPress = agrume.savePhotoOnLongPress
     agrume.show(from: self)
   }
   

--- a/Example/Agrume Example/SingleImageModalViewController.swift
+++ b/Example/Agrume Example/SingleImageModalViewController.swift
@@ -15,6 +15,7 @@ final class SingleImageModalViewController: UIViewController {
   
   @IBAction private func openImage(_ sender: Any) {
     let agrume = Agrume(image: #imageLiteral(resourceName: "MapleBacon"), background: .blurred(.regular))
+    agrume.onLongPress = agrume.savePhotoOnLongPress
     agrume.show(from: self)
   }
   

--- a/Example/Agrume Example/SingleImageModalViewController.swift
+++ b/Example/Agrume Example/SingleImageModalViewController.swift
@@ -16,7 +16,7 @@ final class SingleImageModalViewController: UIViewController {
   @IBAction private func openImage(_ sender: Any) {
     let agrume = Agrume(image: #imageLiteral(resourceName: "MapleBacon"), background: .blurred(.regular))
     let helper = makeHelper()
-    agrume.onLongPress = helper.makeLongPressGesture
+    agrume.onLongPress = helper.makeSaveToLibraryLongPressGesture
     agrume.show(from: self)
   }
   

--- a/Example/Agrume Example/SingleImageModalViewController.swift
+++ b/Example/Agrume Example/SingleImageModalViewController.swift
@@ -15,7 +15,8 @@ final class SingleImageModalViewController: UIViewController {
   
   @IBAction private func openImage(_ sender: Any) {
     let agrume = Agrume(image: #imageLiteral(resourceName: "MapleBacon"), background: .blurred(.regular))
-    agrume.onLongPress = agrume.savePhotoOnLongPress
+    let helper = makeHelper()
+    agrume.onLongPress = helper.makeLongPressGesture
     agrume.show(from: self)
   }
   
@@ -23,4 +24,16 @@ final class SingleImageModalViewController: UIViewController {
     presentingViewController?.dismiss(animated: true, completion: nil)
   }
 
+  private func makeHelper() -> AgrumePhotoLibraryHelper {
+    let saveButtonTitle = NSLocalizedString("Save Photo", comment: "Save Photo")
+    let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel")
+    let helper = AgrumePhotoLibraryHelper(saveButtonTitle: saveButtonTitle, cancelButtonTitle: cancelButtonTitle) { error in
+      guard error == nil else {
+        print("Could not save your photo")
+        return
+      }
+      print("Photo has been saved to your library")
+    }
+    return helper
+  }
 }

--- a/Example/Agrume Example/SingleImageViewController.swift
+++ b/Example/Agrume Example/SingleImageViewController.swift
@@ -10,8 +10,21 @@ final class SingleImageViewController: UIViewController {
   private lazy var agrume = Agrume(image: #imageLiteral(resourceName: "MapleBacon"), background: .blurred(.regular))
 
   @IBAction private func openImage(_ sender: Any) {
-    agrume.onLongPress = agrume.savePhotoOnLongPress
+    let helper = makeHelper()
+    agrume.onLongPress = helper.makeLongPressGesture
     agrume.show(from: self)
   }
 
+  private func makeHelper() -> AgrumePhotoLibraryHelper {
+    let saveButtonTitle = NSLocalizedString("Save Photo", comment: "Save Photo")
+    let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel")
+    let helper = AgrumePhotoLibraryHelper(saveButtonTitle: saveButtonTitle, cancelButtonTitle: cancelButtonTitle) { error in
+      guard error == nil else {
+        print("Could not save your photo")
+        return
+      }
+      print("Photo has been saved to your library")
+    }
+    return helper
+  }
 }

--- a/Example/Agrume Example/SingleImageViewController.swift
+++ b/Example/Agrume Example/SingleImageViewController.swift
@@ -10,6 +10,7 @@ final class SingleImageViewController: UIViewController {
   private lazy var agrume = Agrume(image: #imageLiteral(resourceName: "MapleBacon"), background: .blurred(.regular))
 
   @IBAction private func openImage(_ sender: Any) {
+    agrume.onLongPress = agrume.savePhotoOnLongPress
     agrume.show(from: self)
   }
 

--- a/Example/Agrume Example/SingleImageViewController.swift
+++ b/Example/Agrume Example/SingleImageViewController.swift
@@ -11,7 +11,7 @@ final class SingleImageViewController: UIViewController {
 
   @IBAction private func openImage(_ sender: Any) {
     let helper = makeHelper()
-    agrume.onLongPress = helper.makeLongPressGesture
+    agrume.onLongPress = helper.makeSaveToLibraryLongPressGesture
     agrume.show(from: self)
   }
 

--- a/Example/Agrume Example/SingleURLViewController.swift
+++ b/Example/Agrume Example/SingleURLViewController.swift
@@ -14,7 +14,7 @@ final class SingleURLViewController: UIViewController {
     agrume.onLongPress = helper.makeSaveToLibraryLongPressGesture
     agrume.show(from: self)
   }
-  
+
   private func makeHelper() -> AgrumePhotoLibraryHelper {
     let saveButtonTitle = NSLocalizedString("Save Photo", comment: "Save Photo")
     let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel")
@@ -27,5 +27,4 @@ final class SingleURLViewController: UIViewController {
     }
     return helper
   }
-
 }

--- a/Example/Agrume Example/SingleURLViewController.swift
+++ b/Example/Agrume Example/SingleURLViewController.swift
@@ -10,15 +10,22 @@ final class SingleURLViewController: UIViewController {
   @IBAction private func openURL(_ sender: Any) {
     let agrume = Agrume(url: URL(string: "https://www.dropbox.com/s/mlquw9k6ogvspox/MapleBacon.png?raw=1")!,
                         background: .blurred(.regular))
-    agrume.onLongPress = agrume.savePhotoOnLongPress
-    agrume.photoSavedToLibrary = { error in
-      if error != nil { // we got back an error!
-        print"Could not save your photo")
-      } else {
-        print("Photo has been saved to your library")
-      }
-    }
+    let helper = makeHelper()
+    agrume.onLongPress = helper.makeLongPressGesture
     agrume.show(from: self)
+  }
+  
+  private func makeHelper() -> AgrumePhotoLibraryHelper {
+    let saveButtonTitle = NSLocalizedString("Save Photo", comment: "Save Photo")
+    let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel")
+    let helper = AgrumePhotoLibraryHelper(saveButtonTitle: saveButtonTitle, cancelButtonTitle: cancelButtonTitle) { error in
+      guard error == nil else {
+        print("Could not save your photo")
+        return
+      }
+      print("Photo has been saved to your library")
+    }
+    return helper
   }
 
 }

--- a/Example/Agrume Example/SingleURLViewController.swift
+++ b/Example/Agrume Example/SingleURLViewController.swift
@@ -11,7 +11,7 @@ final class SingleURLViewController: UIViewController {
     let agrume = Agrume(url: URL(string: "https://www.dropbox.com/s/mlquw9k6ogvspox/MapleBacon.png?raw=1")!,
                         background: .blurred(.regular))
     let helper = makeHelper()
-    agrume.onLongPress = helper.makeLongPressGesture
+    agrume.onLongPress = helper.makeSaveToLibraryLongPressGesture
     agrume.show(from: self)
   }
   

--- a/Example/Agrume Example/SingleURLViewController.swift
+++ b/Example/Agrume Example/SingleURLViewController.swift
@@ -10,6 +10,14 @@ final class SingleURLViewController: UIViewController {
   @IBAction private func openURL(_ sender: Any) {
     let agrume = Agrume(url: URL(string: "https://www.dropbox.com/s/mlquw9k6ogvspox/MapleBacon.png?raw=1")!,
                         background: .blurred(.regular))
+    agrume.onLongPress = agrume.savePhotoOnLongPress
+    agrume.photoSavedToLibrary = { error in
+      if error != nil { // we got back an error!
+        print"Could not save your photo")
+      } else {
+        print("Photo has been saved to your library")
+      }
+    }
     agrume.show(from: self)
   }
 


### PR DESCRIPTION
Created this function so that users can easily use a simple default UIAlertController with two options:
Save Photo and Cancel

using it in just one single line:
agrume.onLongPress = agrume.photoSavedToLibrary

I didnt add it as a default longPress function because some user's might not want this and also they might have not have NSPhotoLibraryUsageDescription and NSPhotoLibraryAddUsageDescription in their info.plist.

@JanGorman 
Tell me what you think about this. If it needs some change or any suggestion how to improve.

I was thinking to add some documentation in the readme after this gets merged to master 👍 