### PR TITLE
Reword swift package name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "MyLibrary",
+    name: "Agrume",
     platforms: [
         .iOS(.v9)
     ],


### PR DESCRIPTION
This PR changes the name of the swift package from placeholder 'MyLibrary' to the actual name 'Agrume'.