### PR TITLE
exposed background

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -16,7 +16,7 @@ public final class Agrume: UIViewController {
 
   private var images: [AgrumeImage]!
   private let startIndex: Int
-  private let background: Background
+  public var background: Background
   private let dismissal: Dismissal
   
   private var overlayView: AgrumeOverlayView?


### PR DESCRIPTION
small fix proposing exposing Agrume's background. This is something I've done locally in my project, and it works without issue. This allows for the use of custom background colors that fit the image being presented when using a global Agrume instance opposed to creating a new one each time.