### PR TITLE
Update package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
         .package(url: "https://github.com/kirualex/SwiftyGif", .upToNextMajor(from: "5.0.0"))
     ],
     targets: [
-        .target(name: "Agrume", dependencies: ["SwiftyGif"], path: "./Agrume"),
-        .testTarget(name: "AgrumeTests", dependencies: ["Agrume"], path: "./AgrumeTests")
+        .target(name: "Agrume", dependencies: ["SwiftyGif"], path: "./Agrume")
     ]
 )


### PR DESCRIPTION
This PR drops the `.testTarget` target as Agrume doesn't have unit tests to run and a warning is thrown by XCode.