### PR TITLE
Center cells horizontally for macCatalyst

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -456,7 +456,15 @@ extension Agrume: UICollectionViewDataSource {
 
 }
 
-extension Agrume: UICollectionViewDelegate {
+extension Agrume: UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
+  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    // Center cells horizontally
+    let cellWidth = view.bounds.width
+    let totalWidth = cellWidth * CGFloat(numberOfImages)
+    let leftInset = max(0, (collectionView.bounds.width - totalWidth) / 2)
+    let rightInset = leftInset
+    return UIEdgeInsets(top: 0, left: leftInset, bottom: 0, right: rightInset)
+  }
 
   public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
     didScroll?(currentlyVisibleCellIndex())


### PR DESCRIPTION
While using macCatalyst, the agrume cell will be left aligned in screen and not taking the full width probably because macCatalyst is not feeding the width properly. Nonetheless I think it won't hurt to center align the cells - the solution is from https://stackoverflow.com/a/37065909/1032900.

Tested on iOS device and it still work as expected.