### PR TITLE
Allow replacing an image while maintaining the zoom scale and position

### DIFF
--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -252,6 +252,8 @@ public final class Agrume: UIViewController {
         $0.title = newTitle
       }
     }
+    
+    markAsUpdatingSameCell(at: index)
     images[index] = replacement
     reload()
   }
@@ -270,13 +272,18 @@ public final class Agrume: UIViewController {
         $0.title = newTitle
       }
     }
+    
+    markAsUpdatingSameCell(at: index)
+    images[index] = replacement
+    reload()
+  }
+  
+  private func markAsUpdatingSameCell(at index: Int) {
     collectionView.visibleCells.forEach({ cell in
       if let cell = cell as? AgrumeCell, cell.index == index {
         cell.updatingImageOnSameCell = true
       }
     })
-    images[index] = replacement
-    reload()
   }
   
   override public func viewDidLoad() {

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -279,11 +279,11 @@ public final class Agrume: UIViewController {
   }
   
   private func markAsUpdatingSameCell(at index: Int) {
-    collectionView.visibleCells.forEach({ cell in
+    collectionView.visibleCells.forEach { cell in
       if let cell = cell as? AgrumeCell, cell.index == index {
         cell.updatingImageOnSameCell = true
       }
-    })
+    }
   }
   
   override public func viewDidLoad() {

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -270,6 +270,11 @@ public final class Agrume: UIViewController {
         $0.title = newTitle
       }
     }
+    collectionView.visibleCells.forEach({ cell in
+      if let cell = cell as? AgrumeCell, cell.index == index {
+        cell.updatingImageOnSameCell = true
+      }
+    })
     images[index] = replacement
     reload()
   }
@@ -466,6 +471,7 @@ extension Agrume: UICollectionViewDataSource {
 
     spinner.alpha = 1
     fetchImage(forIndex: indexPath.item) { [weak self] image in
+      cell.index = indexPath.item
       cell.image = image
       self?.spinner.alpha = 0
     }

--- a/Agrume/Agrume.swift
+++ b/Agrume/Agrume.swift
@@ -242,9 +242,16 @@ public final class Agrume: UIViewController {
   /// - Parameters:
   ///   - index: The target index
   ///   - image: The replacement UIImage
-  public func updateImage(at index: Int, with image: UIImage) {
+  ///   - newTitle: The new title, if nil then no change
+  public func updateImage(at index: Int, with image: UIImage, newTitle: NSAttributedString? = nil) {
     assert(images.count > index)
-    let replacement = with(images[index]) { $0.image = image }
+    let replacement = with(images[index]) {
+      $0.url = nil
+      $0.image = image
+      if let newTitle = newTitle {
+        $0.title = newTitle
+      }
+    }
     images[index] = replacement
     reload()
   }
@@ -253,9 +260,16 @@ public final class Agrume: UIViewController {
   /// - Parameters:
   ///   - index: The target index
   ///   - url: The replacement URL
-  public func updateImage(at index: Int, with url: URL) {
+  ///   - newTitle: The new title, if nil then no change
+  public func updateImage(at index: Int, with url: URL, newTitle: NSAttributedString? = nil) {
     assert(images.count > index)
-    let replacement = with(images[index]) { $0.url = url }
+    let replacement = with(images[index]) {
+      $0.image = nil
+      $0.url = url
+      if let newTitle = newTitle {
+        $0.title = newTitle
+      }
+    }
     images[index] = replacement
     reload()
   }

--- a/Agrume/AgrumeCell.swift
+++ b/Agrume/AgrumeCell.swift
@@ -70,7 +70,9 @@ final class AgrumeCell: UICollectionViewCell {
                relativeZoomScaleBeforeUpdate > 1 {
         // Since navigation require zoom level to be at 1, so zoomScale > 1 implies that this image set is trigger by image update instead cell re-use.
         // In this case we retain the pre-update zoom scale & position
-        zoom(to: CGPoint(x: scrollView.frame.size.width * relativeCenterBeforeUpdate.x, y: scrollView.frame.size.height * relativeCenterBeforeUpdate.y), scale: relativeZoomScaleBeforeUpdate)
+        zoom(to: CGPoint(x: scrollView.frame.size.width * relativeCenterBeforeUpdate.x, y: scrollView.frame.size.height * relativeCenterBeforeUpdate.y),
+             scale: relativeZoomScaleBeforeUpdate,
+             animated: false)
       }
     }
   }
@@ -165,7 +167,7 @@ extension AgrumeCell: UIGestureRecognizerDelegate {
     }
   }
   
-  private func zoom(to point: CGPoint, scale: CGFloat) {
+  private func zoom(to point: CGPoint, scale: CGFloat, animated: Bool = true) {
     let factor = 1 / scrollView.zoomScale
     let translatedZoom = CGPoint(
       x: (point.x + scrollView.contentOffset.x) * factor,
@@ -182,7 +184,7 @@ extension AgrumeCell: UIGestureRecognizerDelegate {
     CATransaction.setCompletionBlock { [unowned self] in
       self.contentView.isUserInteractionEnabled = true
     }
-    scrollView.zoom(to: destination, animated: true)
+    scrollView.zoom(to: destination, animated: animated)
     CATransaction.commit()
   }
 

--- a/Agrume/AgrumeCell.swift
+++ b/Agrume/AgrumeCell.swift
@@ -55,7 +55,7 @@ final class AgrumeCell: UICollectionViewCell {
   
 
   // index of the cell in the collection view
-  var index = 0
+  var index: Int?
   
   // if set to true, it means we are updating image on the same cell, so we want to reserve the zoom level & position
   var updatingImageOnSameCell = false

--- a/Agrume/AgrumeCell.swift
+++ b/Agrume/AgrumeCell.swift
@@ -161,7 +161,7 @@ extension AgrumeCell: UIGestureRecognizerDelegate {
     }
   }
   
-  private func zoom(to point: CGPoint, scale: CGFloat, animated: Bool = true) {
+  private func zoom(to point: CGPoint, scale: CGFloat) {
     let factor = 1 / scrollView.zoomScale
     let translatedZoom = CGPoint(
       x: (point.x + scrollView.contentOffset.x) * factor,
@@ -178,7 +178,7 @@ extension AgrumeCell: UIGestureRecognizerDelegate {
     CATransaction.setCompletionBlock { [unowned self] in
       self.contentView.isUserInteractionEnabled = true
     }
-    scrollView.zoom(to: destination, animated: animated)
+    scrollView.zoom(to: destination, animated: true)
     CATransaction.commit()
   }
 

--- a/Example/Agrume Example.xcodeproj/project.pbxproj
+++ b/Example/Agrume Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		39CA658926EFFC5700A5A910 /* URLUpdatedToImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39CA658826EFFC5700A5A910 /* URLUpdatedToImageViewController.swift */; };
 		771DA7342179EF1800541206 /* SwiftyGif.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 771DA7332179EF1800541206 /* SwiftyGif.framework */; };
 		9464AFE923C692C7006ADEBD /* OverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9464AFE823C692C7006ADEBD /* OverlayView.swift */; };
 		948117D723C7A83600AE200D /* MultipleImagesCustomOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 948117D623C7A83600AE200D /* MultipleImagesCustomOverlayView.swift */; };
@@ -85,6 +86,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		39CA658826EFFC5700A5A910 /* URLUpdatedToImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLUpdatedToImageViewController.swift; sourceTree = "<group>"; };
 		771DA7332179EF1800541206 /* SwiftyGif.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwiftyGif.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9464AFE823C692C7006ADEBD /* OverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayView.swift; sourceTree = "<group>"; };
 		948117D623C7A83600AE200D /* MultipleImagesCustomOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleImagesCustomOverlayView.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				E77809E21D17821400CC60F1 /* SingleImageModalViewController.swift */,
 				F2D9598D1B1A133800073772 /* SingleImageViewController.swift */,
 				F2D959901B1A140200073772 /* SingleURLViewController.swift */,
+				39CA658826EFFC5700A5A910 /* URLUpdatedToImageViewController.swift */,
 				F2A520181B130C7E00924912 /* Supporting Files */,
 			);
 			path = "Agrume Example";
@@ -354,6 +357,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E77809E31D17821400CC60F1 /* SingleImageModalViewController.swift in Sources */,
+				39CA658926EFFC5700A5A910 /* URLUpdatedToImageViewController.swift in Sources */,
 				F2D959911B1A140200073772 /* SingleURLViewController.swift in Sources */,
 				F2D7BA1F20A47FB500D5EE66 /* AnimatedGifViewController.swift in Sources */,
 				948117D723C7A83600AE200D /* MultipleImagesCustomOverlayView.swift in Sources */,

--- a/Example/Agrume Example/Base.lproj/Main.storyboard
+++ b/Example/Agrume Example/Base.lproj/Main.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="hvw-Fc-Hya">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="hvw-Fc-Hya">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -19,14 +20,14 @@
                             <tableViewSection id="G8U-Te-22y">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="B8G-6P-mPd" style="IBUITableViewCellStyleDefault" id="w7N-rQ-qPl">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="w7N-rQ-qPl" id="hqp-mY-i6Y">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Single Image" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="B8G-6P-mPd">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -39,14 +40,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="aEU-7W-Plq" style="IBUITableViewCellStyleDefault" id="j4X-AW-zfT">
-                                        <rect key="frame" x="0.0" y="72" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="68.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="j4X-AW-zfT" id="f60-hI-Igw">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Single Image (Background Color)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="aEU-7W-Plq">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -59,14 +60,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="X5Q-TL-Ye4" style="IBUITableViewCellStyleDefault" id="P2k-4H-XYA">
-                                        <rect key="frame" x="0.0" y="116" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="112.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="P2k-4H-XYA" id="CI0-n8-Oon">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Single Image (Presented Modally)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="X5Q-TL-Ye4">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -79,14 +80,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="X1o-ud-2Lf" style="IBUITableViewCellStyleDefault" id="Y3u-BR-FIv">
-                                        <rect key="frame" x="0.0" y="160" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="156.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Y3u-BR-FIv" id="wnK-Jn-DTV">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Single URL" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="X1o-ud-2Lf">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -98,15 +99,35 @@
                                             <segue destination="0uE-gB-lH7" kind="show" id="6zz-0b-FxF"/>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="hJe-Pi-Ws2" style="IBUITableViewCellStyleDefault" id="mvx-7A-Sbz">
+                                        <rect key="frame" x="0.0" y="200.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="mvx-7A-Sbz" id="7kP-Et-OLo">
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Image that updates" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hJe-Pi-Ws2">
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="PbM-Nv-AQD" kind="show" id="ZZI-cr-wla"/>
+                                        </connections>
+                                    </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="KA2-Jt-so7" style="IBUITableViewCellStyleDefault" id="S2t-PK-6Yf">
-                                        <rect key="frame" x="0.0" y="204" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="244.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="S2t-PK-6Yf" id="GoN-iW-IGx">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Multiple Images" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="KA2-Jt-so7">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -119,14 +140,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="7Ry-kq-3Ny" style="IBUITableViewCellStyleDefault" id="0zw-Kd-4qa">
-                                        <rect key="frame" x="0.0" y="248" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="288.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0zw-Kd-4qa" id="XcZ-9j-6kr">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Multiple URLs" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7Ry-kq-3Ny">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -139,14 +160,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="fD2-aN-XiL" style="IBUITableViewCellStyleDefault" id="ixM-8I-FhX">
-                                        <rect key="frame" x="0.0" y="292" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="332.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ixM-8I-FhX" id="UGU-yB-7dF">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Animated Gif Support" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="fD2-aN-XiL">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -159,14 +180,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="EYU-A6-RJZ" style="IBUITableViewCellStyleDefault" id="Ute-DI-Wu6">
-                                        <rect key="frame" x="0.0" y="336" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="376.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ute-DI-Wu6" id="Q01-NE-Gug">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="With Close Button" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="EYU-A6-RJZ">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -179,14 +200,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="7mq-3b-nAO" style="IBUITableViewCellStyleDefault" id="N7W-k7-LDv">
-                                        <rect key="frame" x="0.0" y="380" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="420.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="N7W-k7-LDv" id="7al-78-I8z">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="With Custom Close Button" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7mq-3b-nAO">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -199,14 +220,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="ZaI-Dt-0fe" style="IBUITableViewCellStyleDefault" id="ZAu-QB-w7B">
-                                        <rect key="frame" x="0.0" y="424" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="464.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZAu-QB-w7B" id="DLR-f3-3RS">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="With Custom Overlay View" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ZaI-Dt-0fe">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -244,7 +265,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rzx-2V-YhL">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rzx-2V-YhL">
                                 <rect key="frame" x="152.5" y="318.5" width="70" height="30"/>
                                 <state key="normal" title="Open URL">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -277,7 +298,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aeg-qq-ukm">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aeg-qq-ukm">
                                 <rect key="frame" x="146" y="318.5" width="83" height="30"/>
                                 <state key="normal" title="Open Image"/>
                                 <connections>
@@ -356,7 +377,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KmE-2Z-HVh">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KmE-2Z-HVh">
                                 <rect key="frame" x="146" y="318.5" width="83" height="30"/>
                                 <state key="normal" title="Open Image"/>
                                 <connections>
@@ -387,7 +408,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QC9-3M-Kjs">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QC9-3M-Kjs">
                                 <rect key="frame" x="146" y="318.5" width="83" height="30"/>
                                 <state key="normal" title="Open Image"/>
                                 <connections>
@@ -418,7 +439,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ucZ-1n-E69">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ucZ-1n-E69">
                                 <rect key="frame" x="146" y="318.5" width="83" height="30"/>
                                 <state key="normal" title="Open Image">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -451,7 +472,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aRQ-YY-XnL">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aRQ-YY-XnL">
                                 <rect key="frame" x="146" y="318.5" width="83" height="30"/>
                                 <state key="normal" title="Open Image"/>
                                 <connections>
@@ -482,7 +503,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3k9-ik-WIf">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3k9-ik-WIf">
                                 <rect key="frame" x="146" y="308.5" width="83" height="30"/>
                                 <state key="normal" title="Open Image">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -644,5 +665,39 @@
             </objects>
             <point key="canvasLocation" x="476" y="2909"/>
         </scene>
+        <!--URL Updated To Image View Controller-->
+        <scene sceneID="MxJ-8f-nTL">
+            <objects>
+                <viewController id="PbM-Nv-AQD" customClass="URLUpdatedToImageViewController" customModule="Agrume_Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="LFE-2E-n0H"/>
+                        <viewControllerLayoutGuide type="bottom" id="Ls8-Go-E4L"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="HeN-dE-gaV">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tMZ-QA-edO">
+                                <rect key="frame" x="152" y="318" width="70" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Open URL"/>
+                                <connections>
+                                    <action selector="openURL:" destination="PbM-Nv-AQD" eventType="touchUpInside" id="lPc-Mw-FGo"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="VqU-65-vLB"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="URa-Fs-JlI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1281" y="2266"/>
+        </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/Agrume Example/URLUpdatedToImageViewController.swift
+++ b/Example/Agrume Example/URLUpdatedToImageViewController.swift
@@ -1,0 +1,25 @@
+//
+//  URLUpdatedToImageViewController.swift
+//  Agrume Example
+//
+//  Created by Bao Lei on 9/13/21.
+//  Copyright © 2021 Schnaub. All rights reserved.
+//
+
+import Agrume
+import UIKit
+
+final class URLUpdatedToImageViewController: UIViewController {
+
+  @IBAction private func openURL(_ sender: Any) {
+    let agrume = Agrume(
+      url: URL(string: "https://placekitten.com/500/500")!,
+      background: .blurred(.regular)
+    )
+    agrume.show(from: self)
+    
+    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+      agrume.updateImage(at: 0, with: UIImage(named: "MapleBacon")!)
+    }
+  }
+}

--- a/Example/Agrume Example/URLUpdatedToImageViewController.swift
+++ b/Example/Agrume Example/URLUpdatedToImageViewController.swift
@@ -19,7 +19,7 @@ final class URLUpdatedToImageViewController: UIViewController {
     agrume.show(from: self)
     
     DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-      agrume.updateImage(at: 0, with: UIImage(named: "MapleBacon")!)
+      agrume.updateImage(at: 0, with: URL(string: "https://placekitten.com/2500/2500")!)
     }
   }
 }


### PR DESCRIPTION
Thanks so much for building this amazing library! Could you please consider this change to support the image replacing use case?

Imagine you start an Agrume with a lower resolution image which was already loaded and cached, and now you want to download a higher resolution copy and replace it once the high resolution image is ready. This change allows replacing between URL based image and UIImage, and allows the replacing process to maintain the zoom scale and position, so it doesn't interrupt the user's flow.

Please see the video demo (included in the Example app as well):

https://user-images.githubusercontent.com/1700014/133555632-e92d9df1-a74a-41ba-9824-7e3ced600fab.mov

