### PR TITLE
Fix unowned reference that can cause crash

### DIFF
--- a/Agrume/AgrumeCell.swift
+++ b/Agrume/AgrumeCell.swift
@@ -175,7 +175,9 @@ extension AgrumeCell: UIGestureRecognizerDelegate {
     contentView.isUserInteractionEnabled = false
     
     CATransaction.begin()
-    CATransaction.setCompletionBlock { [unowned self] in
+    CATransaction.setCompletionBlock { [weak self] in
+      // captures self weakly to avoid extending the lifetime of the cell  
+      guard let self = self else { return }
       self.contentView.isUserInteractionEnabled = true
     }
     scrollView.zoom(to: destination, animated: true)


### PR DESCRIPTION
The completion handler can outlive the cell so this will crash if the cell is deallocated mid animation. 

Fixes #326