### PR TITLE
navigation bar Appearance Transparent

### DIFF
--- a/Agrume/AgrumeOverlayView.swift
+++ b/Agrume/AgrumeOverlayView.swift
@@ -31,6 +31,15 @@ final class AgrumeCloseButtonOverlayView: AgrumeOverlayView {
     navigationBar.shadowImage = UIImage()
     navigationBar.setBackgroundImage(UIImage(), for: .default)
     navigationBar.items = [navigationItem]
+                                                            
+      if #available(iOS 13.0, *) {
+          let app = UINavigationBarAppearance()
+          app.configureWithOpaqueBackground()
+          app.backgroundColor = .clear
+          UINavigationBar.appearance().standardAppearance = app
+          UINavigationBar.appearance().scrollEdgeAppearance = app
+      }
+      
   }
   
   private lazy var navigationItem = UINavigationItem(title: "")


### PR DESCRIPTION
used UINavigationBarAppearance to resolve the issue of Navbar not transparent on ios 16

Now it can also be used for projects which have the bridging with ObjectC modules.
They have to just create a wrapper class and use it. 